### PR TITLE
fix asterisk variable which is not getting the value

### DIFF
--- a/lca-chimevc-stack/cloudformation-templates/chime-vc-with-asterisk-server.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/chime-vc-with-asterisk-server.yaml
@@ -648,6 +648,7 @@ Resources:
           sed -i "s/PHONE_NUMBER/$PHONE_NUMBER/g" /etc/asterisk/pjsip.conf
           sed -i "s/VOICE_CONNECTOR/$VOICE_CONNECTOR/g" /etc/asterisk/pjsip.conf
           sed -i "s/INSTANCE_ID/$INSTANCE_ID/g" /etc/asterisk/pjsip.conf
+          sed -i "s/PHONE_NUMBER/$PHONE_NUMBER/g" /etc/asterisk/extensions.conf
           groupadd asterisk || echo "Group already exists"
           useradd -r -d /var/lib/asterisk -g asterisk asterisk || echo "User already exists"
           usermod -aG audio,dialout asterisk
@@ -779,7 +780,7 @@ Resources:
                 include => catch-all
 
                 [phones]
-                exten => $PhoneNumber,1,Dial(PJSIP/PHONE_NUMBER)
+                exten => PHONE_NUMBER,1,Dial(PJSIP/PHONE_NUMBER)
             /etc/asterisk/asterisk.conf:
               content: !Sub |
                 [options]


### PR DESCRIPTION
Fix Asterisk configuration.
We cannot play live two-person phone calls with current `extensions.conf`.

The commit below seems not reflecting all the changes, which creates the different `extensions.conf` because it failed to pass the value to the variable.
https://github.com/aws-samples/amazon-transcribe-live-call-analytics/commit/ad58e2800e83919f11fc9c3acae51589a960c77d

